### PR TITLE
Finalizar checkout

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+API_URL=http://localhost:5000

--- a/components/Cart.unit.spec.js
+++ b/components/Cart.unit.spec.js
@@ -119,14 +119,14 @@ describe('Cart - unit', () => {
   });
 
   it('should display an input type e-mail when there are items in the cart', () => {
-    const { wrapper } = mountCart();
+    const { wrapper } = mountCart(server);
     const input = wrapper.find('input[type="email"]');
 
     expect(input.exists()).toBe(true);
   });
 
   it('should hide the input type e-mail when there are NO items in the cart', async () => {
-    const { wrapper } = mountCart();
+    const { wrapper } = mountCart(server);
 
     wrapper.setProps({
       products: [],
@@ -140,7 +140,7 @@ describe('Cart - unit', () => {
   });
 
   it('should emit checkout event and send email when checkout button is clicked', async () => {
-    const { wrapper } = mountCart();
+    const { wrapper } = mountCart(server);
     const form = wrapper.find('[data-testid="checkout-form"]');
     const input = wrapper.find('input[type="email"]');
     const email = 'vedovelli@gmail.com';
@@ -157,7 +157,7 @@ describe('Cart - unit', () => {
   });
 
   it('should NOT emit checkout event when input email is empty', async () => {
-    const { wrapper } = mountCart();
+    const { wrapper } = mountCart(server);
     const button = wrapper.find('[data-testid="checkout-button"]');
 
     await button.trigger('click');

--- a/components/Cart.unit.spec.js
+++ b/components/Cart.unit.spec.js
@@ -117,4 +117,51 @@ describe('Cart - unit', () => {
     expect(cartManager.getState().items).toHaveLength(0);
     expect(cartManager.getState().open).toBe(false);
   });
+
+  it('should display an input type e-mail when there are items in the cart', () => {
+    const { wrapper } = mountCart();
+    const input = wrapper.find('input[type="email"]');
+
+    expect(input.exists()).toBe(true);
+  });
+
+  it('should hide the input type e-mail when there are NO items in the cart', async () => {
+    const { wrapper } = mountCart();
+
+    wrapper.setProps({
+      products: [],
+    });
+
+    await Vue.nextTick();
+
+    const input = wrapper.find('input[type="email"]');
+
+    expect(input.exists()).toBe(false);
+  });
+
+  it('should emit checkout event and send email when checkout button is clicked', async () => {
+    const { wrapper } = mountCart();
+    const form = wrapper.find('[data-testid="checkout-form"]');
+    const input = wrapper.find('input[type="email"]');
+    const email = 'vedovelli@gmail.com';
+
+    input.setValue(email);
+
+    await form.trigger('submit');
+
+    expect(wrapper.emitted().checkout).toBeTruthy();
+    expect(wrapper.emitted().checkout).toHaveLength(1);
+    expect(wrapper.emitted().checkout[0][0]).toEqual({
+      email,
+    });
+  });
+
+  it('should NOT emit checkout event when input email is empty', async () => {
+    const { wrapper } = mountCart();
+    const button = wrapper.find('[data-testid="checkout-button"]');
+
+    await button.trigger('click');
+
+    expect(wrapper.emitted().checkout).toBeFalsy();
+  });
 });

--- a/components/Cart.vue
+++ b/components/Cart.vue
@@ -39,23 +39,41 @@
       data-testid="cart-item"
     />
     <h3 v-if="!hasProducts">Cart is empty</h3>
-    <a
-      v-else
-      class="flex items-center justify-center mt-4 px-3 py-2 bg-blue-600 text-white text-sm uppercase font-medium rounded hover:bg-blue-500 focus:outline-none focus:bg-blue-500"
-    >
-      <span>Checkout</span>
-      <svg
-        class="h-5 w-5 mx-2"
-        fill="none"
-        stroke-linecap="round"
-        stroke-linejoin="round"
-        stroke-width="2"
-        viewBox="0 0 24 24"
-        stroke="currentColor"
+    <form data-testid="checkout-form" @submit.prevent="checkout">
+      <div v-if="hasProducts" class="mt-4">
+        <hr />
+        <label
+          class="block text-gray-700 mt-2 text-sm font-bold mb-2"
+          for="email"
+        >
+          Email
+        </label>
+        <input
+          id="email"
+          v-model="email"
+          type="email"
+          class="shadow appearance-none border rounded w-full py-2 px-3 text-gray-700 leading-tight focus:outline-none focus:shadow-outline"
+        />
+      </div>
+      <button
+        data-testid="checkout-button"
+        type="submit"
+        class="flex items-center justify-center mt-4 px-3 py-2 bg-blue-600 text-white text-sm uppercase font-medium rounded hover:bg-blue-500 focus:outline-none focus:bg-blue-500"
       >
-        <path d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
-      </svg>
-    </a>
+        <span>Checkout</span>
+        <svg
+          class="h-5 w-5 mx-2"
+          fill="none"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="2"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+        >
+          <path d="M17 8l4 4m0 0l-4 4m4-4H3"></path>
+        </svg>
+      </button>
+    </form>
   </div>
 </template>
 
@@ -75,6 +93,11 @@ export default {
       default: () => [],
     },
   },
+  data() {
+    return {
+      email: '',
+    };
+  },
   computed: {
     hasProducts() {
       return this.products.length > 0;
@@ -83,6 +106,12 @@ export default {
   methods: {
     close() {
       this.$emit('close');
+    },
+    checkout() {
+      /* istanbul ignore else */
+      if (this.email) {
+        this.$emit('checkout', { email: this.email });
+      }
     },
   },
 };

--- a/layouts/default.integration.spec.js
+++ b/layouts/default.integration.spec.js
@@ -1,0 +1,104 @@
+import { mount } from '@vue/test-utils';
+import flushPromises from 'flush-promises';
+import axios from 'axios';
+import DefaultLayout from '@/layouts/default';
+import Cart from '@/components/Cart';
+import { CartManager } from '@/managers/CartManager';
+import { makeServer } from '@/miragejs/server';
+
+jest.mock('axios', () => ({
+  post: jest.fn(() => ({ order: { id: 111 } })),
+  setHeader: jest.fn(),
+}));
+
+const cartManager = new CartManager();
+
+function mountComponent(
+  providedCartManager = cartManager,
+  providedAxios = axios
+) {
+  return mount(DefaultLayout, {
+    mocks: {
+      $cart: providedCartManager,
+      $axios: providedAxios,
+    },
+    stubs: {
+      Nuxt: true,
+    },
+  });
+}
+
+describe('Default Layout', () => {
+  let server;
+  let products;
+
+  beforeEach(() => {
+    server = makeServer({ environment: 'test' });
+    products = server.createList('product', 2);
+  });
+
+  afterEach(() => {
+    server.shutdown();
+    jest.clearAllMocks();
+  });
+
+  it('should set email header on Axios when Cart emmits checkout event', async () => {
+    const wrapper = mountComponent();
+    const cartComponent = wrapper.findComponent(Cart).vm;
+    const email = 'vedovelli@gmail.com';
+
+    await cartComponent.$emit('checkout', { email });
+
+    expect(axios.setHeader).toHaveBeenCalledTimes(1);
+    expect(axios.setHeader).toHaveBeenCalledWith('email', email);
+  });
+
+  it('should call Axios.post with the right endpoint and send products', async () => {
+    jest.spyOn(cartManager, 'getState').mockReturnValue({
+      items: products,
+    });
+
+    jest.spyOn(cartManager, 'clearProducts');
+
+    const wrapper = mountComponent(cartManager);
+    const cartComponent = wrapper.findComponent(Cart).vm;
+    const email = 'vedovelli@gmail.com';
+
+    await cartComponent.$emit('checkout', { email });
+
+    expect(axios.post).toHaveBeenCalledTimes(1);
+    expect(axios.post).toHaveBeenCalledWith('/api/order', { products });
+  });
+
+  it('should call cartManager.clearProducts on success', async () => {
+    jest.spyOn(cartManager, 'getState').mockReturnValue({
+      items: products,
+    });
+
+    jest.spyOn(cartManager, 'clearProducts');
+
+    const wrapper = mountComponent(cartManager);
+    const cartComponent = wrapper.findComponent(Cart).vm;
+    const email = 'vedovelli@gmail.com';
+
+    await cartComponent.$emit('checkout', { email });
+
+    expect(cartManager.clearProducts).toHaveBeenCalledTimes(1);
+  });
+
+  it('should display error notice when Axios.post fails', async () => {
+    jest.spyOn(cartManager, 'getState').mockReturnValue({
+      items: products,
+    });
+
+    jest.spyOn(axios, 'post').mockRejectedValue({});
+
+    const wrapper = mountComponent(cartManager, axios);
+    const cartComponent = wrapper.findComponent(Cart).vm;
+
+    await cartComponent.$emit('checkout', { email: 'vedovelli@gmail.com' });
+    await flushPromises();
+
+    expect(wrapper.find('[data-testid="error-message"]').exists()).toBe(true);
+  });
+});

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -98,7 +98,12 @@
         </nav>
       </div>
     </header>
-    <cart :is-open="isCartOpen" :products="products" @close="toggleCart" />
+    <cart
+      :products="products"
+      :is-open="isCartOpen"
+      @close="toggleCart"
+      @checkout="checkout"
+    />
     <Nuxt />
     <footer class="bg-gray-200">
       <div
@@ -119,6 +124,11 @@ import Cart from '@/components/Cart';
 export default {
   name: 'DefaultLayout',
   components: { Cart },
+  data() {
+    return {
+      errorMessage: '',
+    };
+  },
   computed: {
     isCartOpen() {
       return this.$cart.getState().open;
@@ -126,8 +136,21 @@ export default {
     products() {
       return this.$cart.getState().items;
     },
+    hasError() {
+      return this.errorMessage !== '';
+    },
   },
   methods: {
+    async checkout({ email }) {
+      try {
+        const products = this.$cart.getState().items;
+        this.$axios.setHeader('email', email);
+        await this.$axios.post('/api/order', { products });
+        this.$cart.clearProducts();
+      } catch (error) {
+        this.errorMessage = 'Fail to save order';
+      }
+    },
     toggleCart() {
       if (this.$cart.getState().open) {
         this.$cart.close();

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -104,6 +104,7 @@
       @close="toggleCart"
       @checkout="checkout"
     />
+    <h2 v-if="hasError" data-testid="error-message">{{ errorMessage }}</h2>
     <Nuxt />
     <footer class="bg-gray-200">
       <div

--- a/miragejs/seeds/index.js
+++ b/miragejs/seeds/index.js
@@ -13,7 +13,7 @@ const usersSeeder = (server) => {
 };
 
 const productsSeeder = (server) => {
-  server.createList('product', 10);
+  server.createList('product', 24);
 };
 
 export default function seeds(server) {

--- a/miragejs/server.js
+++ b/miragejs/server.js
@@ -13,6 +13,8 @@ const config = (environment) => {
     seeds,
   };
 
+  config.urlPrefix = 'http://localhost:5000';
+
   return config;
 };
 

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -22,12 +22,7 @@ export default {
   components: false,
 
   // Modules for dev and build (recommended): https://go.nuxtjs.dev/config-modules
-  buildModules: [
-    // https://go.nuxtjs.dev/eslint
-    '@nuxtjs/eslint-module',
-    // https://go.nuxtjs.dev/tailwindcss
-    '@nuxtjs/tailwindcss',
-  ],
+  buildModules: ['@nuxtjs/eslint-module', '@nuxtjs/tailwindcss'],
 
   // Modules: https://go.nuxtjs.dev/config-modules
   modules: [
@@ -36,6 +31,10 @@ export default {
     // https://go.nuxtjs.dev/pwa
     '@nuxtjs/pwa',
   ],
+
+  env: {
+    USE_API: !!process.env.USE_API,
+  },
 
   // Axios module configuration: https://go.nuxtjs.dev/config-axios
   axios: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "nuxt",
+    "dev:api": "USE_API=true nuxt",
     "build": "nuxt build",
     "start": "nuxt start",
     "generate": "nuxt generate",
@@ -50,6 +51,7 @@
     "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-nuxt": "^3.1.0",
     "eslint-plugin-vue": "^8.2.0",
+    "flush-promises": "^1.0.2",
     "husky": "^7.0.4",
     "jest": "^27.4.4",
     "lint-staged": "^12.1.2",

--- a/plugins/miragejs.js
+++ b/plugins/miragejs.js
@@ -1,6 +1,6 @@
 import { createServer, Response } from 'miragejs';
 
-if (process.env.NODE_ENV === 'development') {
+if (process.env.NODE_ENV === 'development' && !process.env.USE_API) {
   require('@/miragejs/server').makeServer();
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5459,6 +5459,11 @@ flatten@^1.0.2:
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.3.tgz#c1283ac9f27b368abc1e36d1ff7b04501a30356b"
   integrity sha512-dVsPA/UwQ8+2uoFe5GHtiBMu48dWLTdsuEd7CKGlZlD78r1TTWBvDuFaFGKCo/ZfEr95Uk56vZoX86OsHkUeIg==
 
+flush-promises@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/flush-promises/-/flush-promises-1.0.2.tgz#4948fd58f15281fed79cbafc86293d5bb09b2ced"
+  integrity sha512-G0sYfLQERwKz4+4iOZYQEZVpOt9zQrlItIxQAAYAWpfby3gbHrx0osCHz5RLl/XoXevXk0xoN4hDFky/VV9TrA==
+
 flush-write-stream@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/flush-write-stream/-/flush-write-stream-1.1.1.tgz#8dd7d873a1babc207d94ead0c2e0e44276ebf2e8"


### PR DESCRIPTION
Como a API requer que um e-mail seja adicionado ao header das chamadas, permitindo assim que a compra seja feita sem a necessidade da criação de um usuário, é necessário que o Cart tenha um campo para que o usuário informe seu e-mail.

Ao preencher o campo e clicar no botão CHECKOUT, um evento é emitido e o pai do Cart faz a chamada POST para a API, adicionando o email num header e enviando os produtos.

Este PR implementa este caso de uso, com todos os testes necessários.

![image](https://user-images.githubusercontent.com/38411510/202854506-c49c018a-58bb-4472-a8ae-e9c20e14e9d5.png)
